### PR TITLE
Update metadata

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@
 carpentry: 'incubator'
 
 # Overall title for pages.
-title: 'fundamentals of Natural Language Processing (NLP) in Python'
+title: 'Fundamentals of Natural Language Processing (NLP) in Python'
 
 # Date the lesson was created (YYYY-MM-DD, this is empty by default)
 created: 2024-04-24

--- a/episodes/01-preprocessing.Rmd
+++ b/episodes/01-preprocessing.Rmd
@@ -46,10 +46,8 @@ In this episode, we will build a workflow following these steps:
 
 Note that for step 5 we will cover only briefly the code to train your own model, but then we will load the output of already pretrained models. That is because training requires a large amount of data and considerable computing resources/time which are not suitable for a local laptop/computer.
 
-## 1. Formulate the problem
+## 1. Formulate the problem: semantic shift
 In this episode we will be using Dutch newspaper texts to train a Word2Vec model to investigate the notion of *semantic shift*. 
-
-## Semantic shift
 
 Semantic shift, as it is used here, refers to a pair of meanings A and B which are linked by some relation. Either
 diachronically (e.g., Latin *caput* "head" and Italian *capo* "chief") or synchronically, e.g. as two meanings that co-exist
@@ -106,7 +104,7 @@ Look at what the [Tubantia newspaper](https://resolver.kb.nl/resolve?urn=KBPERS0
 
 ::::::::::::::::::::::::::::::::::::::: 
 
-## 2. Download the data
+## 2. Download and inspect the data
 
 We download a page from the journal [Algemeen Dagblad](https://www.delpher.nl/nl/kranten/view?coll=ddd&query=&cql%5B%5D=%28date+_gte_+%2220-07-1969%22%29&redirect=true&sortfield=date&resultscoll=dddtitel&identifier=KBPERS01:002846018:mpeg21&rowid=3) of July 21, 1969 as `txt` and save it as `ad.txt`. We then load this file and store it in a variable called `corpus`.
 
@@ -119,8 +117,6 @@ with open(path) as myfile:
 ::: callout
 The `txt` file provides the text without formatting and images, and is the product of a technique called Optical Character Recognition (OCR). This is a technique in which text from an image is converted into text, and it's a necessary step for any scanned image to obtain plain text. Luckily for us, Delpher has already done this step for us so that we can directly use the txt. However, take into consideration that if you start from an image that contains text, you may need an additional preprocessing step.
 :::
-
-## Inspect the data
 
 We inspect the first line of the imported text:
 
@@ -149,7 +145,7 @@ Python tells us that `corpus` is a `str`, i.e. a string. This means that every s
 
 How do we teach our machine to *segment* the text and keep only the relevant words? This is where `data preprocessing` comes into play. It prepares the text for efficient processing by the model, allowing it to focus on the important parts of the text that contribute to understanding its meaning.
 
-## 3. Prepare data to be ingested by the model (preprocessing)
+## 3. Prepare the data to be ingested by the model (preprocessing)
 
 NLP models work by learning the statistical regularities within the constituent parts of the language (i.e, letters, digits, words and sentences) in a text. However, text contains also other type of information that humans find useful to convey meaning. To signal pauses, give emphasis and convey tone, for instance, we use punctuation. Articles, conjunctions and prepositions also alter the meaning of a sentence. The machine does not know the difference among all of these linguistic units, as it treats them all as equal. Also, the decision to remove or retain these parts of text is quite crucial for training our model, as it affects the quality of generated word vectors.
 

--- a/episodes/02-transformers.md
+++ b/episodes/02-transformers.md
@@ -72,12 +72,7 @@ As in any basic NLP pipeline, the first step is to pre-process the raw text so i
 
 ## BERT Code
 
-Let's see how these components can be manipulated with code. For this we will be using the HugingFace's _transformers_ python library. We can install it with:
-
-```sh
-pip install transformers
-```
-
+Let's see how these components can be manipulated with code. For this we will be using the HugingFace's _transformers_ python library.
 The first two main components we need to initialize are the model and tokenizer. The HuggingFace hub contains thousands of models based on a Transformer architecture for dozens of tasks, data domains and also hundreds of languages. Here we will explore the vanilla English BERT which was how everything started. We can initialize this model with the next lines:
 
 ```python
@@ -506,10 +501,6 @@ The rest is more advanced content (still I leave it here just in case for now).
 ## Testing on CoNLL-03 Benchmark
 
 This model was trained on the CoNLL-03 dataset, therefore we can corroborate how it performs using the test portion of this dataset. To get the data we can use the `datasets` library which is also part of theHuggingFace landscape
-
-```
-pip install datasets
-```
 
 ```python
 from datasets import load_dataset

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ site: sandpaper::sandpaper_site
 ---
 
 ## Welcome
-This lesson is about the fundamentals of Natural Language Processing (NLP) in Python, with applications in the Humanities and Social Sciences.
+This lesson teaches the fundamentals of Natural Language Processing (NLP) in Python, with applications in the Humanities and Social Sciences.
 
 It will equip you with the foundational skills and knowledge needed to carry over text-based research projects. The lesson is designed specifically with researchers in the Humanities and Social Sciences in mind, but is also applicable to other fields of research.
 

--- a/index.md
+++ b/index.md
@@ -3,16 +3,15 @@ site: sandpaper::sandpaper_site
 ---
 
 ## Welcome
-This lesson teaches the fundamentals of Natural Language Processing (NLP) in Python, with applications in the Humanities and Social Sciences.
+This lesson teaches the fundamentals of Natural Language Processing (NLP) in Python. It will equip you with the foundational skills and knowledge needed to carry over text-based research projects. The lesson is designed with researchers in the Humanities and Social Sciences in mind, but is also applicable to other fields of research.
 
-It will equip you with the foundational skills and knowledge needed to carry over text-based research projects. The lesson is designed specifically with researchers in the Humanities and Social Sciences in mind, but is also applicable to other fields of research.
+On the first day we will dive in to text preprocessing and word embeddings while epxloring semantic shifts in various words over multiple decades. The second day begins with an introduction to transformers, and we will work on classification and named entity recognition with the BERT model.  In the afternoon, we willl cover large language language models, and you will learn how to build your own agents.
 
 :::::::::::::::::: checklist
 ## Prerequisites
 Before joining this course, participants should have:
 
 - Basic Python programming skills
-- Basic knowledge of Git and GitHub
 ::::::::::::::::::
 
 ::: instructor

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -118,6 +118,18 @@ To start Jupyter Lab, open a terminal (Mac/Linux) or Command Prompt (Windows) an
 jupyter lab
 ```
 
+## Ollama
+We will use Ollama to run large language models. It can be downloaded here:
+
+https://ollama.com/download
+
+Next, download the model that we will be using from a terminal (Mac/Linux) or Command Prompt (Windows) by typing the command:
+
+```shell
+ollama pull llama3.1:8b
+```
+
+
 ## Data Sets
 
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -139,14 +139,27 @@ FIXME: place any data you want learners to use in `episodes/data` and then use
        link to it, replacing the example.com link.
 -->
 
-For the episode 01: preprocessing and word embeddings (Word2Vec):
+### Delpher newspapers
 
-- Download the [Algemeen Dagblad from July 21 1969](https://www.delpher.nl/nl/kranten/view?coll=ddd&query=&cql%5B%5D=%28date+_gte_+%2220-07-1969%22%29&redirect=true&sortfield=date&resultscoll=dddtitel&identifier=KBPERS01:002846018:mpeg21&rowid=3) as txt file from Delpher. To do so, click on the link and navigate to the right hand side of the web page. There you'll find an icon with an arrow pointing down:
+Download the form page of the [Algemeen Dagblad from July 21 1969](https://www.delpher.nl/nl/kranten/view?coll=ddd&query=&cql%5B%5D=%28date+_gte_+%2220-07-1969%22%29&redirect=true&sortfield=date&resultscoll=dddtitel&identifier=KBPERS01:002846018:mpeg21&rowid=3) as txt file from Delpher. To do so, click on the link and navigate to the right hand side of the web page. There you'll find an icon with an arrow pointing down:
 
 ![arrow](fig/setup_download_arrow.png)
 
-Click on this icon and select `txt` among the downloading options
+Click on this icon and select `txt` among the downloading options. Save the file as `ad.txt` in the folder that you will be using for the workshop. 
 
+Similarly, download the following pages from <i>Amigoe di Curacao : weekblad voor de Curacaosche eilanden</i> as txt file
 
-- Download Word2Vec models trained on 6 national Dutch newspaper data spanning a time period from 1950 to 1989 (Wevers, M., 2019). These models are available on [Zenodo](https://zenodo.org/records/3237380).
+- [Page 1](https://www.delpher.nl/nl/kranten/view?query=the+moon&coll=ddd&identifier=ddd:010460545:mpeg21:p012&resultsidentifier=ddd:010460545:mpeg21:a0134&rowid=4)
+- [Page 2](https://www.delpher.nl/nl/kranten/view?query=moon+landing&coll=ddd&page=1&facets%5Bspatial%5D%5B%5D=Nederlandse+Antillen&identifier=ddd:010460616:mpeg21:a0146&resultsidentifier=ddd:010460616:mpeg21:a0146&rowid=1)
+- [Page 3](https://www.delpher.nl/nl/kranten/view?query=moon+landing&coll=ddd&page=1&facets%5Bspatial%5D%5B%5D=Nederlandse+Antillen&identifier=ddd:010460520:mpeg21:a0167&resultsidentifier=ddd:010460520:mpeg21:a0167&rowid=7)
+
+### Word2Vec
+Download Word2Vec models trained on 6 national Dutch newspaper data spanning a time period from 1950 to 1989 (Wevers, M., 2019). These models are available on [Zenodo](https://zenodo.org/records/3237380).
+
+### Spacy Dutch
+Download the [trained pipelines for Dutch from Spacy](https://spacy.io/models/nl/). To do so, open a terminal (Mac/Linux) or Command Prompt (Windows) and type the command:
+```shell
+python -m spacy download nl_core_news_sm
+```
+
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -23,6 +23,88 @@ you are ready to go as soon as the workshop begins.
 [Pip](https://pip.pypa.io/en/stable/) is the package management system built into Python.
 Pip should be available in your system once you installed Python successfully.
 
+
+Open a terminal (Mac/Linux) or Command Prompt (Windows) and run the following commands.
+
+1. Create a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#create-and-use-virtual-environments) called `nlp_workshop`:
+
+::: spoiler
+
+### On Linux/macOs
+
+```shell
+python3 -m venv nlp_workshop
+```
+
+:::
+
+::: spoiler
+
+### On Windows
+
+```shell
+py -m venv nlp_workshop
+```
+
+:::
+
+2. Activate the newly created virtual environment:
+
+::: spoiler
+
+### On Linux/macOs
+
+```shell
+source nlp_workshop/bin/activate
+```
+
+:::
+
+::: spoiler
+
+### On Windows
+
+```shell
+nlp_workshop\Scripts\activate
+```
+
+:::
+
+Remember that you need to activate your environment every time you restart your terminal!
+
+3. Install the required packages:
+
+::: spoiler
+
+### On Windows
+
+```shell
+nlp_workshop\Scripts\activate
+```
+
+:::
+
+
+::: spoiler
+
+### On Linux/macOs
+
+```shell
+python3 -m pip install jupyter torch transformers scikit-learn spacy gensim langgraph langchain-ollama langchain-text-splitters langchain-nomic seqeval datasets wordcloud
+```
+
+:::
+
+::: spoiler
+
+### On Windows
+
+```shell
+py -m pip install install jupyter torch transformers scikit-learn spacy gensim langgraph langchain-ollama langchain-text-splitters langchain-nomic seqeval datasets wordcloud
+```
+
+:::
+
 ## Jupyter Lab
 
 We will teach using Python in [Jupyter Lab](http://jupyter.org/), a programming environment that runs in a web browser.

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -21,7 +21,7 @@ you are ready to go as soon as the workshop begins.
 ## Installing the required packages
 
 [Pip](https://pip.pypa.io/en/stable/) is the package management system built into Python.
-Pip should be available in your system once you installed Python successfully.
+Pip should be available in your system once you installed Python successfully. Please note that installing the packages can take some time, in particular on Windows.
 
 
 Open a terminal (Mac/Linux) or Command Prompt (Windows) and run the following commands.
@@ -90,7 +90,7 @@ nlp_workshop\Scripts\activate
 ### On Linux/macOs
 
 ```shell
-python3 -m pip install jupyter torch transformers scikit-learn spacy gensim langgraph langchain-ollama langchain-text-splitters langchain-nomic seqeval datasets wordcloud
+python3 -m pip install jupyter torch transformers scikit-learn spacy gensim langgraph langchain-ollama langchain-text-splitters langchain-nomic nomic[local] seqeval datasets wordcloud
 ```
 
 :::

--- a/links.md
+++ b/links.md
@@ -1,10 +1,1 @@
-<!-- 
-Place links that you need to refer to multiple times across pages here. Delete
-any links that you are not going to use. 
- -->
-
-[pandoc]: https://pandoc.org/MANUAL.html
-[r-markdown]: https://rmarkdown.rstudio.com/
-[rstudio]: https://www.rstudio.com/
-[carpentries-workbench]: https://carpentries.github.io/sandpaper-docs/
-
+ 

--- a/workshops.md
+++ b/workshops.md
@@ -6,4 +6,4 @@ date: "2024-10-22"
 
 | Date (YYYY-MM-DD) | Organisation                | Location                   | Comments |
 |-------------------|-----------------------------|----------------------------|----------|
-| 2025-04-01        | Netherlands eScience Center | Amsterdam, The Netherlands |          |
+| 2025-25-03        | Netherlands eScience Center | Amsterdam, The Netherlands |          |


### PR DESCRIPTION
This PR was created along the way of creating the metadata for the NLP workshop in this repo: https://github.com/esciencecenter-digital-skills/workshop-metadata/pull/149

It primarily updates the setup instructions:
- packages to be downloaded
- downloading ollama + llama model
- downloading data sets

Other minor changes:
- Capitalise the name of the workshop
- minor changes to the chapter titles in episode 1
- remove pip install statements from transformer episodes, as this has been moved to the setup instructions
- update the index.md in line with the description for the website in the metadata repo
- update workshop dates
- empty the links file


Fixes #13 and #20 